### PR TITLE
tox.ini: Add py33 + format tweaks

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-REQUESTS_CA_BUNDLE=`python -m pytest_httpbin.certs` py.test tests/
+REQUESTS_CA_BUNDLE=`python -m pytest_httpbin.certs` py.test "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ envlist = py26, py27, py33, py34, pypy
 [testenv]
 deps = pytest
        requests
-commands = ./runtests.sh
+commands = ./runtests.sh {posargs:tests/}


### PR DESCRIPTION
Support py33, because the tests pass, so why not? :)

```
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  congratulations :)
```
