### PR TITLE
Use version.py file in __init__.py to be more DRY

### DIFF
--- a/pytest_httpbin/__init__.py
+++ b/pytest_httpbin/__init__.py
@@ -1,6 +1,8 @@
 import pytest
 
-__version__ = '0.0.3'
+with open("pytest_httpbin/version.py") as f:
+    code = compile(f.read(), "pytest_httpbin/version.py", 'exec')
+    exec(code)
 
 use_class_based_httpbin = pytest.mark.usefixtures("class_based_httpbin")
 use_class_based_httpbin_secure = pytest.mark.usefixtures("class_based_httpbin_secure")


### PR DESCRIPTION
Silly to duplicate the version in two places. This gets it down to one.
