### PR TITLE
Fix broken version code

### DIFF
--- a/pytest_httpbin/__init__.py
+++ b/pytest_httpbin/__init__.py
@@ -1,7 +1,13 @@
+import os
+
 import pytest
 
-with open("pytest_httpbin/version.py") as f:
-    code = compile(f.read(), "pytest_httpbin/version.py", 'exec')
+
+here = os.path.dirname(__file__)
+version_file = os.path.join(here, "version.py")
+
+with open(version_file) as f:
+    code = compile(f.read(), version_file, 'exec')
     exec(code)
 
 use_class_based_httpbin = pytest.mark.usefixtures("class_based_httpbin")


### PR DESCRIPTION
0.0.4 had a bug that causes this:

```
  File "/Users/marca/python/virtualenvs/httpie/lib/python2.7/site-packages/pkg_resources.py", line 2184, in load
    ['__name__'])
  File "/Users/marca/python/virtualenvs/httpie/lib/python2.7/site-packages/pytest_httpbin/__init__.py", line 3, in <module>
    with open("pytest_httpbin/version.py") as f:
IOError: [Errno 2] No such file or directory: 'pytest_httpbin/version.py'
```
