### PR TITLE
No longer require decorator module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     keywords='pytest-httpbin testing pytest httpbin',
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     include_package_data = True, # include files listed in MANIFEST.in
-    install_requires = ['Flask','decorator','httpbin','six'],
+    install_requires = ['Flask','httpbin','six'],
 
     # the following makes a plugin available to pytest
     entry_points = {


### PR DESCRIPTION
AFAICS the code does not in fact require this any more. It was
used by `pytest_httpbin/packages/httpbin/filters.py`, which was
dropped in commit 7911550c.