### PR TITLE
Allow to run httpbin on fixed port using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ def test_that_my_library_works_kinda_ok(httpbin_secure):
     assert requests.get(httpbin_secure.url + '/get/').status_code == 200
 ```
 
-It's actually starting 2 web servers in separate threads in the background: one HTTP and one HTTPS. The servers are started on a random port, on the loopback interface on your machine. Pytest-httpbin includes a self-signed certificate.  If your library verifies certificates against a CA (and it should), you'll have to add the CA from pytest-httpbin.  The path to the pytest-httpbin CA bundle can by found like this `python -m pytest_httpbin.certs`.
+It's actually starting 2 web servers in separate threads in the background: one HTTP and one HTTPS. The servers are started on a random port (see bellow for fixed port support), on the loopback interface on your machine. Pytest-httpbin includes a self-signed certificate.  If your library verifies certificates against a CA (and it should), you'll have to add the CA from pytest-httpbin.  The path to the pytest-httpbin CA bundle can by found like this `python -m pytest_httpbin.certs`.
 
 For example in requests, you can set the `REQUESTS_CA_BUNDLE` python path.  You can run your tests like this:
 
@@ -83,6 +83,14 @@ class TestClassBassedTests(unittest.TestCase):
         assert requests.get(self.httpbin_secure.url + '/get').response
 ```
 
+## Running the server on fixed port
+
+Sometimes a randomized port can be a problem. Worry not, you can fix the port number to a desired value with the `HTTPBIN_HTTP_PORT` and `HTTPBIN_HTTPS_PORT` environment variables. If those are defined during pytest plugins are loaded, `httbin` and `httpbin_secure` fixtures will run on given ports. You can run your tests like this:
+
+```bash
+HTTPBIN_HTTP_PORT=8080 HTTPBIN_HTTPS_PORT=8443 py.test tests/
+```
+
 ## Installation
 
 All you need to do is this:
@@ -115,6 +123,8 @@ tox
 
 ## Changelog
 
+* unreleased:
+  * Allow to run httpbin on fixed port using environment variables
 * 0.2.3: 
   * Another attempt to fix #32 (Rare bug, only happens on Travis)
 * 0.2.2: 

--- a/pytest_httpbin/serve.py
+++ b/pytest_httpbin/serve.py
@@ -82,8 +82,12 @@ class Server(object):
     HTTP server running a WSGI application in its own thread.
     """
 
+    port_envvar = 'HTTPBIN_HTTP_PORT'
+
     def __init__(self, host='127.0.0.1', port=0, application=None, **kwargs):
         self.app = application
+        if self.port_envvar in os.environ:
+            port = int(os.environ[self.port_envvar])
         self._server = make_server(
             host,
             port,
@@ -101,7 +105,8 @@ class Server(object):
         )
 
     def __del__(self):
-        self.stop()
+        if hasattr(self, '_server'):
+            self.stop()
 
     def start(self):
         self._thread.start()
@@ -121,6 +126,8 @@ class Server(object):
 
 
 class SecureServer(Server):
+    port_envvar = 'HTTPBIN_HTTPS_PORT'
+
     def __init__(self, host='127.0.0.1', port=0, application=None, **kwargs):
         kwargs['server_class'] = SecureWSGIServer
         super(SecureServer, self).__init__(host, port, application, **kwargs)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,9 +2,12 @@
 # -*- coding: utf8 -*-
 # vim: set fileencoding=utf8 :
 
+import os
 import requests
 import pytest
 from util import get_raw_http_response
+from pytest_httpbin import serve
+from httpbin import app as httpbin_app
 
 
 def test_content_type_header_not_automatically_added(httpbin):
@@ -50,3 +53,42 @@ def test_dont_crash_on_certificate_problems(httpbin_secure):
         httpbin_secure + '/get',
         verify = True,
     )
+
+
+@pytest.mark.parametrize('protocol', ('http', 'https'))
+def test_fixed_port_environment_variables(protocol):
+    """
+    Note that we cannot test the fixture here because it is session scoped
+    and was already started. Thus, let's just test a new Server instance.
+    """
+    if protocol == 'http':
+        server_cls = serve.Server
+        envvar = 'HTTPBIN_HTTP_PORT'
+    elif protocol == 'https':
+        server_cls = serve.SecureServer
+        envvar = 'HTTPBIN_HTTPS_PORT'
+    else:
+        raise RuntimeError('Unexpected protocol param: {0}'.format(protocol))
+
+    # just have different port to avoid adrress already in use
+    # if the second test run too fast after the first one (happens on pypy)
+    port = 12345 + len(protocol)
+
+    try:
+        envvar_original = os.environ.get(envvar, None)
+        os.environ[envvar] = str(port)
+        server = server_cls(application=httpbin_app)
+        assert server.port == port
+    finally:
+        # if we don't do this, it blocks:
+        try:
+            server.start()
+            server.stop()
+        except UnboundLocalError:
+            pass
+
+        # restore the original environ:
+        if envvar_original is None:
+            del os.environ[envvar]
+        else:
+            os.environ[envvar] = envvar_original


### PR DESCRIPTION
Fixes https://github.com/kevin1024/pytest-httpbin/issues/24