### PR TITLE
Only use @pytest.fixture decorator once

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,4 +3,6 @@ import pytest
 from pytest_httpbin.plugin import httpbin_ca_bundle
 
 
-pytest.fixture(autouse=True)(httpbin_ca_bundle)
+@pytest.fixture(autouse=True, scope='function')
+def httpbin_ca_bundle_autoused(httpbin_ca_bundle):
+    pass


### PR DESCRIPTION
This is now required in pytest >= 3.6

See https://github.com/pytest-dev/pytest/issues/3518

Fixes https://github.com/kevin1024/pytest-httpbin/issues/49