### PR TITLE
Include regression tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@
 # it's already declared in setup.py
 include pytest_httpbin/certs/*
 include DESCRIPTION.rst
+recursive-include tests *.py


### PR DESCRIPTION
In OpenBSD we use the regression tests in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball makes that much easier.
