### PR TITLE
httpbin_secure: fix redirect Location to have "https://" scheme

### DIFF
--- a/pytest_httpbin/serve.py
+++ b/pytest_httpbin/serve.py
@@ -69,6 +69,7 @@ class SecureWSGIServer(WSGIServer):
                 server_side=True,
                 suppress_ragged_eofs=False,
             )
+            self.base_environ['HTTPS'] = 'yes'
             self.RequestHandlerClass(ssock, client_address, self)
         except Exception as e:
             print("pytest-httpbin server hit an exception serving request: %s" % e)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -92,3 +92,14 @@ def test_fixed_port_environment_variables(protocol):
             del os.environ[envvar]
         else:
             os.environ[envvar] = envvar_original
+
+
+def test_redirect_location_is_https_for_secure_server(httpbin_secure):
+    assert httpbin_secure.url.startswith('https://')
+    response = requests.get(
+        httpbin_secure + "/redirect-to?url=/html",
+        allow_redirects=False
+    )
+    assert response.status_code == 302
+    assert response.headers.get('Location')
+    assert response.headers['Location'].startswith('https://')


### PR DESCRIPTION
This PR fixes the problem with secure server that had a missing feature in the part where HTTPS connection was terminated: it was not setting `HTTPS` WSGI environment variable as required by [wsgiref.util.guess_scheme](https://docs.python.org/3/library/wsgiref.html#wsgiref.util.guess_scheme). As a result, the server when trying to autogenerate an absolute URL for `Location` header would end up with something like:
```
Location: http://127.0.0.1:${HTTPS_PORT}/${RELATIVE_PATH}
```

That would result in an error down the road with some HTTP clients, e.g. `requests`, where it would try to follow a redirect opening a plaintext HTTP connection to a port that expected HTTPS and it resulted in the following error:
```
pytest-httpbin server hit an exception serving request: [SSL: HTTP_REQUEST] http request (_ssl.c:1125)
```

Ultimately, it started breaking CI builds for [vcrpy](https://github.com/immerrr/vcrpy/runs/4205197603?check_suite_focus=true#step:6:2872)