### PR TITLE
Use actions/setup-python's to cache pip

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,21 +24,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'setup.py',
-            'setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            setup.cfg
+            setup.py
 
       - name: Install
         run: |


### PR DESCRIPTION
Caching pip is now built into https://github.com/actions/setup-python, so we can simplify the config.

Docs: https://github.com/actions/setup-python#caching-packages-dependencies