### PR TITLE
Assert httpbin_secure doesn't redirect to http://

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,4 +121,4 @@ def test_redirect_location_is_https_for_secure_server(httpbin_secure):
     )
     assert response.status_code == 302
     assert response.headers.get("Location")
-    assert response.headers["Location"].startswith("https://")
+    assert not response.headers["Location"].startswith("http://")


### PR DESCRIPTION
Currently, this asserts that the redirect Location header uses https:// explicitly. But the current version of httpbin seem to use a relative URL for that, which should also work.