### PR TITLE
Fix test_redirect_location_is_https_for_secure_server

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,4 +121,4 @@ def test_redirect_location_is_https_for_secure_server(httpbin_secure):
     )
     assert response.status_code == 302
     assert response.headers.get("Location")
-    assert response.headers["Location"].startswith("https://")
+    assert response.headers["Location"].endswith("/html")


### PR DESCRIPTION
- Flask 2.1.x and above returns relative location header
see: https://github.com/pallets/werkzeug/issues/2352