### PR TITLE
fix test_dont_crash_on_handshake_timeout on pypy3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12-dev]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12-dev, pypy-3.7, pypy-3.8, pypy-3.9]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -62,7 +62,7 @@ def test_dont_crash_on_handshake_timeout(httpbin_secure, capsys):
 
     assert (
         re.match(
-            r"pytest-httpbin server hit an exception serving request: .* The "
+            r"pytest-httpbin server hit an exception serving request:.* The "
             "handshake operation timed out\nattempting to ignore so the rest "
             "of the tests can run\n",
             capsys.readouterr().out,


### PR DESCRIPTION
Fix test_dont_crash_on_handshake_timeout() not to require a C source location in the handshake timeout exception message.  PyPy3 does not implement the SSL module in pure C, so it does not have that.